### PR TITLE
Fix scan_time ERB helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.1.2
+
+- Fix lookup of `scan_time` ERB helper
+- Refactor template handling
+
 ## v0.1.1
 
 - Add configurability via environment variable

--- a/lib/inspec-reporter-flex/mixin/erb_helpers.rb
+++ b/lib/inspec-reporter-flex/mixin/erb_helpers.rb
@@ -1,10 +1,12 @@
 module InspecPlugins::FlexReporter
   module ErbHelpers
-    # Return latest start time of the scan
+    # Return approximate time of the scan
     #
-    # @return [DateTime] Timestamp of the last scan in the profile
+    # @return [DateTime] Timestamp of the first scan in the profile
     def scan_time
-      DateTime.strptime(report[:profiles].last[:controls].last[:results].last[:start_time])
+      scan_time = report[:profiles].detect { |p| p[:controls].detect { |c| c[:results].detect { |r| !r.empty? } } }.dig(:controls, 0, :results, 0, :start_time)
+
+      DateTime.strptime(scan_time)
     end
 
     # Execute a remote command.

--- a/lib/inspec-reporter-flex/mixin/file_resolver.rb
+++ b/lib/inspec-reporter-flex/mixin/file_resolver.rb
@@ -1,11 +1,11 @@
 module InspecPlugins::FlexReporter
   module FileResolver
-    # Resolve the absolute path for a file in order absolute path/gem bundled file/relative.
+    # Resolve the full path for a file in order absolute path/gem bundled file/relative.
     #
     # @param [String] name Name or path of a file to resolve
     # @return [String] Absolute path to the file, if any
     # @raise [IOError] if file not found
-    def resolve_path(name)
+    def full_path(name)
       if absolute_path?(name)
         name
       elsif relative_path?(name)

--- a/lib/inspec-reporter-flex/reporter.rb
+++ b/lib/inspec-reporter-flex/reporter.rb
@@ -10,12 +10,11 @@ module InspecPlugins::FlexReporter
 
     ENV_PREFIX = "INSPEC_REPORTER_FLEX_".freeze
 
-    attr_writer :config, :env, :inspec_config, :logger
+    attr_writer :config, :env, :inspec_config, :logger, :template_contents
 
     # Render report
     def render
-      template_file = resolve_path(config["template_file"])
-      template = ERB.new(File.read(template_file))
+      template = ERB.new(template_contents)
 
       # Use JSON Reporter base's `report` to have pre-processed data
       mushy_report = Hashie::Mash.new(report)
@@ -53,6 +52,14 @@ module InspecPlugins::FlexReporter
     end
 
     private
+
+    # Read contents of requested template.
+    #
+    # @return [String] ERB Template
+    # @raise [IOError]
+    def template_contents
+      @template_contents ||= File.read full_path(config["template_file"])
+    end
 
     # Initialize configuration with defaults and Plugin config.
     #

--- a/lib/inspec-reporter-flex/version.rb
+++ b/lib/inspec-reporter-flex/version.rb
@@ -1,5 +1,5 @@
 module InspecPlugins
   module FlexReporter
-    VERSION = "0.1.1".freeze
+    VERSION = "0.1.2".freeze
   end
 end


### PR DESCRIPTION
### Description

Fix lookup of  `scan_time` to match the first non-empty result, instead of the last overall.

In cases where the last control was skipped or empty, this resulted in a crash of the reporter.

### Issues Resolved

no formal issue

### Check List

- [X] All tests pass.
- [ ] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable

