### PR TITLE
Fix absolute path detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.1.3
+
+- Fix absolute path detection to check for existence of `template_file`
+
 ## v0.1.2
 
 - Fix lookup of `scan_time` ERB helper

--- a/lib/inspec-reporter-flex/mixin/file_resolver.rb
+++ b/lib/inspec-reporter-flex/mixin/file_resolver.rb
@@ -22,7 +22,23 @@ module InspecPlugins::FlexReporter
     # @param [String] name name or path of a file
     # @return [Boolean] if it is an absolute path
     def absolute_path?(name)
-      name.start_with? "/"
+      absolute_unix_path?(name) || absolute_windows_path?(name)
+    end
+
+    # Is this an absolute path on UNIX systems?
+    #
+    # @param [String] name name or path of a file
+    # @return [Boolean] if it is an absolute path
+    def absolute_unix_path?(name)
+      File.exist?(name) && name.start_with?("/")
+    end
+
+    # Is this an absolute path on Windows systems?
+    #
+    # @param [String] name name or path of a file
+    # @return [Boolean] if it is an absolute path
+    def absolute_windows_path?(name)
+      File.exist?(name) && name.match?(/^[a-zA-C]:/)
     end
 
     # Is this an relative path?

--- a/lib/inspec-reporter-flex/version.rb
+++ b/lib/inspec-reporter-flex/version.rb
@@ -1,5 +1,5 @@
 module InspecPlugins
   module FlexReporter
-    VERSION = "0.1.2".freeze
+    VERSION = "0.1.3".freeze
   end
 end


### PR DESCRIPTION
### Description

Fixes handling of absolute paths.

### Issues Resolved

Previously when adding a `template_file` option and this file did not exist, the plugin would silently fall back to the bundled ERB file. With this patch, execution will be stopped with a message about the specified template being missing.

### Check List

none
